### PR TITLE
Fix crashes and robustness issues in zone.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git workflow
+
+- **Never `git commit` or `git push` without the user's explicit consent.** Do the work,
+  then stop and ask.
+- When asking, show the list of changed files (e.g. `git status` / `git diff --stat`)
+  alongside the question so the user can see exactly what would be committed.
+- Only commit and push after the user explicitly says yes. A "yes" approves that one
+  set of changes — ask again for the next commit.
+
 ## What this is
 
 A single-file Python CLI (`zone.py`) that downloads the BrandMeister DMR repeater
@@ -73,5 +82,3 @@ additionally drops repeaters with no coordinates and any id starting with `247`.
 - `BM.json`, `a.json`, `b.json` are large downloaded data snapshots, not source.
 - Output XML is import-only; CPS16 cannot paste XML, so this targets CPS2
   (radio firmware R2.10+).
-</content>
-</invoke>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A single-file Python CLI (`zone.py`) that downloads the BrandMeister DMR repeater
+list and emits Motorola MOTOTRBO **CPS2** zone files (XML) for import into Motorola
+DMR radios. Repeaters are filtered by band and by country (MCC), QTH locator, or GPS
+coordinates. There is no package structure, no test suite, and no build step — it is
+run directly as a script.
+
+## Commands
+
+```bash
+# Set up environment (a .venv already exists in the repo)
+pip install -r requirements.txt
+
+# Run (always requires -n, -b, and -t)
+./zone.py -n 'Germany'  -b vhf -t mcc -m 262 -6 -zc 16
+./zone.py -n 'Paris'    -b uhf -t qth -q JN18EU -r 150 -6
+./zone.py -n 'Stockholm' -b uhf -t gps -lat 59.225 -lon 18.250 -6
+
+# Force re-download of the repeater list
+./zone.py ... -f
+```
+
+Negative GPS coordinates must be quoted with a leading space or written as
+`-lon=-93.2780`, otherwise argparse treats them as flags.
+
+## Architecture
+
+The whole pipeline lives in `zone.py` and runs top-to-bottom in `__main__`:
+
+1. `download_file()` — fetches `bm_url` (BrandMeister `/v2/device`) into `BM.json`,
+   only if the file is missing or `-f`/`--force` is given. TLS verification is
+   intentionally disabled (`verify=False`) because of the upstream cert.
+2. `filter_list()` — reads `BM.json`, sorts by callsign + id, and applies all filters,
+   building `filtered_list`. Deduplicates by (rx, tx, callsign). The module-level
+   `existing` dict counts how many repeaters share a callsign so duplicates get
+   `#N` suffixes later.
+3. Output, one of two modes:
+   - **Default:** `process_channels()` chunks `filtered_list` into zones of
+     `--zone-capacity` channels, calls `format_channel()` per repeater, writes one
+     `<zone alias>.xml` per chunk, and prints a `tabulate` summary table.
+   - **`-js`/`--javascript`:** `create_js()` prints repeater objects for an external
+     web map instead of writing XML.
+
+### Channel generation detail
+
+`format_channel()` emits raw CPS2 XML by string interpolation (no XML library).
+A repeater with `rx == tx` (simplex/hotspot) produces a single SLOT2 personality;
+otherwise it produces paired **TS1** and **TS2** personalities. Contents of
+`custom-values.xml` are spliced into every channel only when `-c`/`--customize` is set.
+
+### JS mode is a different beast
+
+`-js`/`--javascript` is a private feature on the `js` branch for the maintainer's own
+internal use — it is not part of the upstream tool and should not be merged to `main`
+or treated as a general feature. It changes filtering semantics, not just output: in
+`filter_list()` the band and location/MCC filters are **skipped entirely** when
+`args.javascript` is set (only `-p`, `-6`, `-cs` still apply). `create_js()`
+additionally drops repeaters with no coordinates and any id starting with `247`.
+
+## Conventions and gotchas
+
+- State flows through module-level globals (`filtered_list`, `existing`,
+  `custom_values`, `qth_coords`) mutated via `global` — not return values.
+- `-m`/`--mcc` accepts a numeric MCC prefix *or* a two-letter country code, which is
+  resolved to MCC(s) via `mobile_codes.alpha2(...)[4]` and may be a list.
+- `last_seen` from the API is UTC; `local_datetime()` converts it to the machine's
+  local timezone for the printed table.
+- `BM.json`, `a.json`, `b.json` are large downloaded data snapshots, not source.
+- Output XML is import-only; CPS16 cannot paste XML, so this targets CPS2
+  (radio firmware R2.10+).
+</content>
+</invoke>

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -37,7 +37,7 @@ Fix: guard that skips coordinate-less repeaters.
 
 ## Robustness / performance
 
-### 4. O(n^2) deduplication
+### 4. O(n^2) deduplication  ✅ DONE (branch claude-fixes)
 `zone.py:152-154`
 
 ```python

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -90,7 +90,7 @@ make it testable.
 - `type(args.mcc) is list` (123) → `isinstance(args.mcc, list)`.
 - `-zc 0` or negative → `range(..., 0)` raises `ValueError`; add a bounds check.
 - Band detection via `rx.startswith('1')`/`'4'` (116-117) is crude but works for 2m/70cm; worth a comment.
-- Optional: warn when `BM.json` is stale (old mtime) so users know to `-f`.
+- ✅ DONE (branch claude-fixes): warn when `BM.json` is more than 7 days old so users know to `-f`.
 
 ## Suggested priority order
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -61,16 +61,9 @@ an invalid two-letter code throws an unhandled exception.
 Fix: use the named field (`.mcc`) and catch the lookup failure with a friendly
 "unknown country code" message.
 
-### 6. `verify=False` disables TLS verification
-`zone.py:82-84`
-
-Globally silences cert warnings and skips verification. If it's only needed for the
-BM cert quirk, consider trying verified first and falling back, or at least
-documenting why.
-
 ## Code quality / maintainability
 
-### 7. ~90% duplicated XML templates
+### 6. ~90% duplicated XML templates
 `zone.py:224-296`
 
 The simplex, TS1, and TS2 blocks repeat nearly every field, and have already diverged:
@@ -78,14 +71,14 @@ The simplex, TS1, and TS2 blocks repeat nearly every field, and have already div
 intentional? Parameterizing a single template (slot, alias suffix, optional ARS) would
 shrink the file and prevent further drift.
 
-### 8. Import-time side effects
+### 7. Import-time side effects
 `zone.py:46-63`
 
 Argument parsing and `qth_coords`/`mcc` computation run at module top level, so the
 file can't be imported or tested without `sys.argv`. Moving this into `main()` would
 make it testable.
 
-### 9. Smaller items
+### 8. Smaller items
 - Bare `open`/`close` in `filter_list` (110, 162) and `write_zone_file` (301-303) — use `with`.
 - `type(args.mcc) is list` (123) → `isinstance(args.mcc, list)`.
 - `-zc 0` or negative → `range(..., 0)` raises `ValueError`; add a bounds check.
@@ -97,5 +90,9 @@ make it testable.
 1. **2 (XML escaping)** and **1 (arg validation)** — done.
 2. **3** — data-dependent crash on coordinate-less repeaters.
 3. **4** — performance + clarity cleanup.
-4. **7 / 8** — larger refactor for a later pass.
-</content>
+4. **6 / 7** — larger refactor for a later pass.
+
+## Notes / deliberate behavior (not bugs)
+
+- `verify=False` on the BrandMeister download (`zone.py:82-84`) is **intentional** —
+  the upstream API cert is the reason. Leave it as is.

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,0 +1,115 @@
+# zone.py — Proposed Improvements
+
+Analysis of `zone.py` on `main`. Grouped by severity. No code changed yet — this is
+a review backlog for further inspection.
+
+## Correctness bugs
+
+### 1. Missing argument validation crashes with ugly tracebacks
+`zone.py:23-34, 57-63`
+
+`-t` is required but the parameter it depends on is not enforced:
+- `-t mcc` without `-m` → `args.mcc` is `None` → line 128 `str(item['id']).startswith(None)` raises `TypeError`.
+- `-t qth` without `-q` → line 58 `maidenhead.to_location(None)` errors.
+- `-t gps` without `-lat`/`-lng` → `qth_coords = (None, None)` → `check_distance` errors.
+
+Fix: a validation block (or argparse sub-parsers / custom check) that prints a clear
+message and exits, instead of a stack trace.
+
+### 2. No XML escaping
+`zone.py:220-296`
+
+`ch_alias`, `ch_cc`, `ch_rx`, `ch_tx` and city are interpolated raw into XML. A
+callsign or city containing `&`, `<`, `>`, or `"` produces malformed XML that CPS2
+will reject. City names with `&` are realistic in the BrandMeister data.
+
+Fix: `xml.sax.saxutils.escape()` on interpolated values, or build XML with
+`xml.etree.ElementTree`.
+
+### 3. Unguarded coordinates in distance filter
+`zone.py:134-135`
+
+For `qth`/`gps`, `check_distance(qth_coords, (item['lat'], item['lng']))` assumes
+every repeater has numeric coords. Entries with `null`/missing `lat`/`lng` will throw
+inside geopy.
+
+Fix: guard that skips coordinate-less repeaters.
+
+### 4. Suspicious `[:-1]` in callsign filter
+`zone.py:144`
+
+```python
+if args.callsign and (not args.callsign in item['callsign'][:-1]):
+```
+
+The `[:-1]` strips the last character of the callsign before the substring match, so
+the filter can never match against the final character. It also runs on the raw
+callsign (before the `.split()[0]` on line 150), so it matches against trailing junk.
+If the intent is "callsign contains this string," this looks like a bug.
+
+ACTION: confirm whether the `[:-1]` is deliberate.
+
+## Robustness / performance
+
+### 5. O(n^2) deduplication
+`zone.py:152-154`
+
+```python
+if any((existing['rx'] == item['rx'] and ...) for existing in filtered_list):
+```
+
+Re-scans the entire `filtered_list` for every candidate. On the ~10 MB `BM.json`
+(thousands of entries) it's noticeably slow. A `set` of `(rx, tx, callsign)` tuples
+makes it O(n).
+
+Bonus: the loop variable is also named `existing`, shadowing the global counter dict
+on line 53. It happens to be safe (generator expressions have their own scope) but
+it's confusing and a refactoring hazard.
+
+### 6. Magic index into `mobile_codes`
+`zone.py:62-63`
+
+`mobile_codes.alpha2(args.mcc)[4]` relies on the namedtuple's positional layout, and
+an invalid two-letter code throws an unhandled exception.
+
+Fix: use the named field (`.mcc`) and catch the lookup failure with a friendly
+"unknown country code" message.
+
+### 7. `verify=False` disables TLS verification
+`zone.py:82-84`
+
+Globally silences cert warnings and skips verification. If it's only needed for the
+BM cert quirk, consider trying verified first and falling back, or at least
+documenting why.
+
+## Code quality / maintainability
+
+### 8. ~90% duplicated XML templates
+`zone.py:224-296`
+
+The simplex, TS1, and TS2 blocks repeat nearly every field, and have already diverged:
+`CP_ARSPLUS` is present in the duplex blocks but absent in the simplex one — is that
+intentional? Parameterizing a single template (slot, alias suffix, optional ARS) would
+shrink the file and prevent further drift.
+
+### 9. Import-time side effects
+`zone.py:46-63`
+
+Argument parsing and `qth_coords`/`mcc` computation run at module top level, so the
+file can't be imported or tested without `sys.argv`. Moving this into `main()` would
+make it testable.
+
+### 10. Smaller items
+- Bare `open`/`close` in `filter_list` (110, 162) and `write_zone_file` (301-303) — use `with`.
+- `type(args.mcc) is list` (123) → `isinstance(args.mcc, list)`.
+- `-zc 0` or negative → `range(..., 0)` raises `ValueError`; add a bounds check.
+- Band detection via `rx.startswith('1')`/`'4'` (116-117) is crude but works for 2m/70cm; worth a comment.
+- Optional: warn when `BM.json` is stale (old mtime) so users know to `-f`.
+
+## Suggested priority order
+
+1. **2 (XML escaping)** and **1 (arg validation)** — cause silently broken output or crashes for normal usage.
+2. **3** and **4** — data-dependent crashes / likely logic bug.
+3. **5** — performance + clarity cleanup.
+4. **8 / 9** — larger refactor for a later pass.
+</content>

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -52,7 +52,7 @@ Bonus: the loop variable is also named `existing`, shadowing the global counter 
 on line 53. It happens to be safe (generator expressions have their own scope) but
 it's confusing and a refactoring hazard.
 
-### 5. Magic index into `mobile_codes`
+### 5. Magic index into `mobile_codes`  ✅ DONE (branch claude-fixes)
 `zone.py:62-63`
 
 `mobile_codes.alpha2(args.mcc)[4]` relies on the namedtuple's positional layout, and

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -1,11 +1,11 @@
 # zone.py — Proposed Improvements
 
-Analysis of `zone.py` on `main`. Grouped by severity. No code changed yet — this is
-a review backlog for further inspection.
+Analysis of `zone.py` on `main`. Grouped by severity. This is a review backlog for
+further inspection.
 
 ## Correctness bugs
 
-### 1. Missing argument validation crashes with ugly tracebacks
+### 1. Missing argument validation crashes with ugly tracebacks  ✅ DONE (branch claude-fixes)
 `zone.py:23-34, 57-63`
 
 `-t` is required but the parameter it depends on is not enforced:
@@ -16,7 +16,7 @@ a review backlog for further inspection.
 Fix: a validation block (or argparse sub-parsers / custom check) that prints a clear
 message and exits, instead of a stack trace.
 
-### 2. No XML escaping
+### 2. No XML escaping  ✅ DONE (branch claude-fixes)
 `zone.py:220-296`
 
 `ch_alias`, `ch_cc`, `ch_rx`, `ch_tx` and city are interpolated raw into XML. A
@@ -26,7 +26,7 @@ will reject. City names with `&` are realistic in the BrandMeister data.
 Fix: `xml.sax.saxutils.escape()` on interpolated values, or build XML with
 `xml.etree.ElementTree`.
 
-### 3. Unguarded coordinates in distance filter
+### 3. Unguarded coordinates in distance filter  ✅ DONE (branch claude-fixes)
 `zone.py:134-135`
 
 For `qth`/`gps`, `check_distance(qth_coords, (item['lat'], item['lng']))` assumes
@@ -35,23 +35,9 @@ inside geopy.
 
 Fix: guard that skips coordinate-less repeaters.
 
-### 4. Suspicious `[:-1]` in callsign filter
-`zone.py:144`
-
-```python
-if args.callsign and (not args.callsign in item['callsign'][:-1]):
-```
-
-The `[:-1]` strips the last character of the callsign before the substring match, so
-the filter can never match against the final character. It also runs on the raw
-callsign (before the `.split()[0]` on line 150), so it matches against trailing junk.
-If the intent is "callsign contains this string," this looks like a bug.
-
-ACTION: confirm whether the `[:-1]` is deliberate.
-
 ## Robustness / performance
 
-### 5. O(n^2) deduplication
+### 4. O(n^2) deduplication
 `zone.py:152-154`
 
 ```python
@@ -66,7 +52,7 @@ Bonus: the loop variable is also named `existing`, shadowing the global counter 
 on line 53. It happens to be safe (generator expressions have their own scope) but
 it's confusing and a refactoring hazard.
 
-### 6. Magic index into `mobile_codes`
+### 5. Magic index into `mobile_codes`
 `zone.py:62-63`
 
 `mobile_codes.alpha2(args.mcc)[4]` relies on the namedtuple's positional layout, and
@@ -75,7 +61,7 @@ an invalid two-letter code throws an unhandled exception.
 Fix: use the named field (`.mcc`) and catch the lookup failure with a friendly
 "unknown country code" message.
 
-### 7. `verify=False` disables TLS verification
+### 6. `verify=False` disables TLS verification
 `zone.py:82-84`
 
 Globally silences cert warnings and skips verification. If it's only needed for the
@@ -84,7 +70,7 @@ documenting why.
 
 ## Code quality / maintainability
 
-### 8. ~90% duplicated XML templates
+### 7. ~90% duplicated XML templates
 `zone.py:224-296`
 
 The simplex, TS1, and TS2 blocks repeat nearly every field, and have already diverged:
@@ -92,14 +78,14 @@ The simplex, TS1, and TS2 blocks repeat nearly every field, and have already div
 intentional? Parameterizing a single template (slot, alias suffix, optional ARS) would
 shrink the file and prevent further drift.
 
-### 9. Import-time side effects
+### 8. Import-time side effects
 `zone.py:46-63`
 
 Argument parsing and `qth_coords`/`mcc` computation run at module top level, so the
 file can't be imported or tested without `sys.argv`. Moving this into `main()` would
 make it testable.
 
-### 10. Smaller items
+### 9. Smaller items
 - Bare `open`/`close` in `filter_list` (110, 162) and `write_zone_file` (301-303) — use `with`.
 - `type(args.mcc) is list` (123) → `isinstance(args.mcc, list)`.
 - `-zc 0` or negative → `range(..., 0)` raises `ValueError`; add a bounds check.
@@ -108,8 +94,8 @@ make it testable.
 
 ## Suggested priority order
 
-1. **2 (XML escaping)** and **1 (arg validation)** — cause silently broken output or crashes for normal usage.
-2. **3** and **4** — data-dependent crashes / likely logic bug.
-3. **5** — performance + clarity cleanup.
-4. **8 / 9** — larger refactor for a later pass.
+1. **2 (XML escaping)** and **1 (arg validation)** — done.
+2. **3** — data-dependent crash on coordinate-less repeaters.
+3. **4** — performance + clarity cleanup.
+4. **7 / 8** — larger refactor for a later pass.
 </content>

--- a/zone.py
+++ b/zone.py
@@ -141,6 +141,8 @@ def filter_list():
     json_list = json.loads(f.read())
     sorted_list = sorted(json_list, key=lambda k: (k['callsign'], int(k["id"])))
 
+    seen = set()
+
     for item in sorted_list:
         if not ((args.band == 'vhf' and item['rx'].startswith('1')) or (
                 args.band == 'uhf' and item['rx'].startswith('4'))):
@@ -180,9 +182,10 @@ def filter_list():
 
         item['callsign'] = item['callsign'].split()[0]
 
-        if any((existing['rx'] == item['rx'] and existing['tx'] == item['tx'] and existing['callsign'] == item[
-            'callsign']) for existing in filtered_list):
+        key = (item['rx'], item['tx'], item['callsign'])
+        if key in seen:
             continue
+        seen.add(key)
 
         if not item['callsign'] in existing: existing[item['callsign']] = 0
         existing[item['callsign']] += 1

--- a/zone.py
+++ b/zone.py
@@ -69,7 +69,11 @@ if args.type == 'gps':
     qth_coords = (args.lat, args.lng)
 
 if args.mcc and not str(args.mcc).isdigit():
-    args.mcc = mobile_codes.alpha2(args.mcc)[4]
+    try:
+        args.mcc = mobile_codes.alpha2(args.mcc).mcc
+    except KeyError:
+        parser.error(f"unknown country code '{args.mcc}'; use a 2-letter ISO code (e.g. LV) "
+                     f"or a numeric MCC prefix.")
 
 
 def check_custom():

--- a/zone.py
+++ b/zone.py
@@ -3,7 +3,8 @@
 import argparse
 from datetime import datetime, timezone
 import json
-from os.path import exists
+from os.path import exists, getmtime
+import time
 from xml.sax.saxutils import escape
 from tabulate import tabulate
 
@@ -96,6 +97,10 @@ def download_file():
             file.write(response.content)
 
         print(f'Saved to {bm_file}')
+    else:
+        age_days = (time.time() - getmtime(bm_file)) / 86400
+        if age_days > 7:
+            print(f'Warning: {bm_file} is {age_days:.0f} days old. Use -f to download a fresh copy.')
 
 
 def xml_escape(value):

--- a/zone.py
+++ b/zone.py
@@ -4,6 +4,7 @@ import argparse
 from datetime import datetime, timezone
 import json
 from os.path import exists
+from xml.sax.saxutils import escape
 from tabulate import tabulate
 
 import geopy.distance
@@ -44,6 +45,13 @@ parser.add_argument('-cs', '--callsign', help='Only list callsigns containing sp
 
 
 args = parser.parse_args()
+
+if args.type == 'mcc' and not args.mcc:
+    parser.error('-t mcc requires -m/--mcc.')
+if args.type == 'qth' and not args.qth:
+    parser.error('-t qth requires -q/--qth.')
+if args.type == 'gps' and (args.lat is None or args.lng is None):
+    parser.error('-t gps requires both -lat and -lng/-lon.')
 
 
 bm_url = 'https://api.brandmeister.network/v2/device'
@@ -90,8 +98,20 @@ def download_file():
         print(f'Saved to {bm_file}')
 
 
+def xml_escape(value):
+    return escape(str(value), {'"': '&quot;', "'": '&apos;'})
+
+
 def check_distance(loc1, loc2):
     return geopy.distance.great_circle(loc1, loc2).km
+
+
+def has_coords(item):
+    # BrandMeister uses null or 0/'0' as a "no location" placeholder; treat those as missing.
+    try:
+        return float(item['lat']) != 0 and float(item['lng']) != 0
+    except (TypeError, ValueError):
+        return False
 
 
 def local_datetime(last_seen: str) -> str:
@@ -131,9 +151,11 @@ def filter_list():
             if not is_starts:
                 continue
 
-        if (args.type == 'qth' or args.type == 'gps') and check_distance(qth_coords,
-                                                                         (item['lat'], item['lng'])) > args.radius:
-            continue
+        if args.type == 'qth' or args.type == 'gps':
+            if not has_coords(item):
+                continue
+            if check_distance(qth_coords, (float(item['lat']), float(item['lng']))) > args.radius:
+                continue
 
         if args.pep and (not str(item['pep']).isdigit() or str(item['pep']) == '0'):
             continue
@@ -186,14 +208,16 @@ def process_channels():
         else:
             zone_alias = f'{args.name} #{chunk_number}'
 
+        zone_alias_xml = xml_escape(zone_alias)
+
         write_zone_file(zone_alias, f'''<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <config>
   <category name="Zone">
-    <set name="Zone" alias="{zone_alias}" key="NORMAL">
+    <set name="Zone" alias="{zone_alias_xml}" key="NORMAL">
       <collection name="ZoneItems">
         {channels}
       </collection>
-      <field name="ZP_ZONEALIAS">{zone_alias}</field>
+      <field name="ZP_ZONEALIAS">{zone_alias_xml}</field>
       <field name="ZP_ZONETYPE" Name="Normal">NORMAL</field>
       <field name="ZP_ZVFNLITEM" Name="None">NONE</field>
       <field name="Comments"></field>
@@ -219,6 +243,12 @@ def format_channel(item):
 
     output_list.append([ch_alias, ch_rx, ch_tx, ch_cc, item['city'], local_datetime(item['last_seen']),
                         f"https://brandmeister.network/?page=repeater&id={item['id']}"])
+
+    # Escape values interpolated into the XML below; the table row above keeps the raw values.
+    ch_alias = xml_escape(ch_alias)
+    ch_rx = xml_escape(ch_rx)
+    ch_tx = xml_escape(ch_tx)
+    ch_cc = xml_escape(ch_cc)
 
     if item['rx'] == item['tx']:
         return f'''


### PR DESCRIPTION
Backlog-driven fixes from IMPROVEMENTS.md. Each change verified against the
cached BrandMeister data; XML output validated as well-formed.

## Fixes
- **Argument validation** — `-t mcc/qth/gps` now require their dependent
  args (`-m` / `-q` / `-lat`+`-lng`) and exit with a clear message instead
  of crashing deep in filtering.
- **XML escaping** — channel/zone aliases and values are escaped, so
  callsigns or names with `& < > "` no longer produce malformed CPS2 XML
  (the printed table keeps raw values).
- **Coordinate guard** — qth/gps distance filtering skips repeaters with
  null or `0`/`'0'` placeholder coordinates (previously crashed geopy or
  matched bogusly).
- **Country code lookup** — uses `mobile_codes.alpha2(...).mcc` instead of a
  positional index, with a friendly error on unknown codes.
- **O(n) dedup** — replaces the O(n^2) rescan with a `set` of
  `(rx, tx, callsign)` keys; output is byte-identical.
- **Stale data warning** — warns when cached `BM.json` is >7 days old.

## Docs
- Added `CLAUDE.md` (architecture + git workflow).
- Added `IMPROVEMENTS.md` review backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)